### PR TITLE
Rely on index.js instead of index.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"aliceblue": [240, 248, 255],
 	"antiquewhite": [250, 235, 215],
 	"aqua": [0, 255, 255],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "color-name",
   "version": "1.0.1",
   "description": "A list of color names and it’s values",
-  "main": "index.json",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
As addressed in https://github.com/MoOx/color-name/pull/2 and noted in https://github.com/MoOx/color/issues/69, this package currently has issues with webpack due to exporting `.json` as the top-level object. This switches over to a simple `index.js` file.

I :heart: `color`, so I'd love to keep using it now that I'm using webpack.

I'm opening this in both places since I can't tell which is the true repo and maintainer.